### PR TITLE
Hide followers/following/boost/fav counts in APIs and UI

### DIFF
--- a/app/javascript/mastodon/features/account/components/header.js
+++ b/app/javascript/mastodon/features/account/components/header.js
@@ -312,20 +312,6 @@ class Header extends ImmutablePureComponent {
 
               {account.get('note').length > 0 && account.get('note') !== '<p></p>' && <div className='account__header__content' dangerouslySetInnerHTML={content} />}
             </div>
-
-            <div className='account__header__extra__links'>
-              <NavLink isActive={this.isStatusesPageActive} activeClassName='active' to={`/accounts/${account.get('id')}`} title={intl.formatNumber(account.get('statuses_count'))}>
-                <strong>{shortNumberFormat(account.get('statuses_count'))}</strong> <FormattedMessage id='account.posts' defaultMessage='Toots' />
-              </NavLink>
-
-              <NavLink exact activeClassName='active' to={`/accounts/${account.get('id')}/following`} title={intl.formatNumber(account.get('following_count'))}>
-                <strong>{shortNumberFormat(account.get('following_count'))}</strong> <FormattedMessage id='account.follows' defaultMessage='Follows' />
-              </NavLink>
-
-              <NavLink exact activeClassName='active' to={`/accounts/${account.get('id')}/followers`} title={intl.formatNumber(account.get('followers_count'))}>
-                <strong>{shortNumberFormat(account.get('followers_count'))}</strong> <FormattedMessage id='account.followers' defaultMessage='Followers' />
-              </NavLink>
-            </div>
           </div>
         </div>
       </div>

--- a/app/javascript/mastodon/features/status/components/detailed_status.js
+++ b/app/javascript/mastodon/features/status/components/detailed_status.js
@@ -169,41 +169,21 @@ export default class DetailedStatus extends ImmutablePureComponent {
     if (status.get('visibility') === 'private') {
       reblogLink = <Icon id={reblogIcon} />;
     } else if (this.context.router) {
-      reblogLink = (
-        <Link to={`/statuses/${status.get('id')}/reblogs`} className='detailed-status__link'>
-          <Icon id={reblogIcon} />
-          <span className='detailed-status__reblogs'>
-            <AnimatedNumber value={status.get('reblogs_count')} />
-          </span>
-        </Link>
-      );
+      reblogLink = <Icon id={reblogIcon} />;
     } else {
       reblogLink = (
         <a href={`/interact/${status.get('id')}?type=reblog`} className='detailed-status__link' onClick={this.handleModalLink}>
           <Icon id={reblogIcon} />
-          <span className='detailed-status__reblogs'>
-            <AnimatedNumber value={status.get('reblogs_count')} />
-          </span>
         </a>
       );
     }
 
     if (this.context.router) {
-      favouriteLink = (
-        <Link to={`/statuses/${status.get('id')}/favourites`} className='detailed-status__link'>
-          <Icon id='star' />
-          <span className='detailed-status__favorites'>
-            <AnimatedNumber value={status.get('favourites_count')} />
-          </span>
-        </Link>
-      );
+      favouriteLink = <Icon id='star' />;
     } else {
       favouriteLink = (
         <a href={`/interact/${status.get('id')}?type=favourite`} className='detailed-status__link' onClick={this.handleModalLink}>
           <Icon id='star' />
-          <span className='detailed-status__favorites'>
-            <AnimatedNumber value={status.get('favourites_count')} />
-          </span>
         </a>
       );
     }
@@ -223,7 +203,7 @@ export default class DetailedStatus extends ImmutablePureComponent {
           <div className='detailed-status__meta'>
             <a className='detailed-status__datetime' href={status.get('url')} target='_blank' rel='noopener noreferrer'>
               <FormattedDate value={new Date(status.get('created_at'))} hour12={false} year='numeric' month='short' day='2-digit' hour='2-digit' minute='2-digit' />
-            </a>{applicationLink} · {reblogLink} · {favouriteLink}
+            </a>{applicationLink}
           </div>
         </div>
       </div>

--- a/app/javascript/mastodon/reducers/accounts_counters.js
+++ b/app/javascript/mastodon/reducers/accounts_counters.js
@@ -6,9 +6,9 @@ import { ACCOUNT_IMPORT, ACCOUNTS_IMPORT } from '../actions/importer';
 import { Map as ImmutableMap, fromJS } from 'immutable';
 
 const normalizeAccount = (state, account) => state.set(account.id, fromJS({
-  followers_count: account.followers_count,
-  following_count: account.following_count,
-  statuses_count: account.statuses_count,
+  followers_count: 999,
+  following_count: 999,
+  statuses_count: 999,
 }));
 
 const normalizeAccounts = (state, accounts) => {
@@ -28,10 +28,9 @@ export default function accountsCounters(state = initialState, action) {
   case ACCOUNTS_IMPORT:
     return normalizeAccounts(state, action.accounts);
   case ACCOUNT_FOLLOW_SUCCESS:
-    return action.alreadyFollowing ? state :
-      state.updateIn([action.relationship.id, 'followers_count'], num => num + 1);
+    return state;
   case ACCOUNT_UNFOLLOW_SUCCESS:
-    return state.updateIn([action.relationship.id, 'followers_count'], num => Math.max(0, num - 1));
+    return state;
   default:
     return state;
   }

--- a/app/serializers/rest/status_serializer.rb
+++ b/app/serializers/rest/status_serializer.rb
@@ -125,6 +125,14 @@ class REST::StatusSerializer < ActiveModel::Serializer
     object.active_mentions.to_a.sort_by(&:id)
   end
 
+  def reblogs_count
+    999
+  end
+
+  def favourites_count
+    999
+  end
+
   class ApplicationSerializer < ActiveModel::Serializer
     attributes :name, :website
   end

--- a/app/views/accounts/_header.html.haml
+++ b/app/views/accounts/_header.html.haml
@@ -12,21 +12,6 @@
             = acct(account)
             = fa_icon('lock') if account.locked?
       .public-account-header__tabs__tabs
-        .details-counters
-          .counter{ class: active_nav_class(short_account_url(account), short_account_with_replies_url(account), short_account_media_url(account)) }
-            = link_to short_account_url(account), class: 'u-url u-uid', title: number_with_delimiter(account.statuses_count) do
-              %span.counter-number= number_to_human account.statuses_count, strip_insignificant_zeros: true
-              %span.counter-label= t('accounts.posts', count: account.statuses_count)
-
-          .counter{ class: active_nav_class(account_following_index_url(account)) }
-            = link_to account_following_index_url(account), title: number_with_delimiter(account.following_count) do
-              %span.counter-number= number_to_human account.following_count, strip_insignificant_zeros: true
-              %span.counter-label= t('accounts.following', count: account.following_count)
-
-          .counter{ class: active_nav_class(account_followers_url(account)) }
-            = link_to account_followers_url(account), title: number_with_delimiter(account.followers_count) do
-              %span.counter-number= number_to_human account.followers_count, strip_insignificant_zeros: true
-              %span.counter-label= t('accounts.followers', count: account.followers_count)
         .spacer
         .public-account-header__tabs__tabs__buttons
           = account_action_button(account)
@@ -36,8 +21,8 @@
 
       .public-account-header__extra__links
         = link_to account_following_index_url(account) do
-          %strong= number_to_human account.following_count, strip_insignificant_zeros: true
-          = t('accounts.following', count: account.following_count)
+          %strong= number_to_human 999, strip_insignificant_zeros: true
+          = t('accounts.following', count: 999)
         = link_to account_followers_url(account) do
-          %strong= number_to_human account.followers_count, strip_insignificant_zeros: true
-          = t('accounts.followers', count: account.followers_count)
+          %strong= number_to_human 999, strip_insignificant_zeros: true
+          = t('accounts.followers', count: 999)

--- a/app/views/directories/index.html.haml
+++ b/app/views/directories/index.html.haml
@@ -40,11 +40,11 @@
 
         .directory__card__extra
           .accounts-table__count
-            = number_to_human account.statuses_count, strip_insignificant_zeros: true
-            %small= t('accounts.posts', count: account.statuses_count).downcase
+            = number_to_human 999, strip_insignificant_zeros: true
+            %small= t('accounts.posts', count: 999).downcase
           .accounts-table__count
-            = number_to_human account.followers_count, strip_insignificant_zeros: true
-            %small= t('accounts.followers', count: account.followers_count).downcase
+            = number_to_human 999, strip_insignificant_zeros: true
+            %small= t('accounts.followers', count: 999).downcase
           .accounts-table__count
             - if account.last_status_at.present?
               %time.time-ago{ datetime: account.last_status_at.to_date.iso8601, title: l(account.last_status_at.to_date) }= l account.last_status_at.to_date

--- a/app/views/statuses/_detailed_status.html.haml
+++ b/app/views/statuses/_detailed_status.html.haml
@@ -58,7 +58,7 @@
         = fa_icon('reply')
       - else
         = fa_icon('reply-all')
-      %span.detailed-status__reblogs>= number_to_human status.replies_count, strip_insignificant_zeros: true
+      %span.detailed-status__reblogs>= '∞'
       = " "
     ·
     - if status.direct_visibility?
@@ -70,12 +70,12 @@
     - else
       = link_to remote_interaction_path(status, type: :reblog), class: 'modal-button detailed-status__link' do
         = fa_icon('retweet')
-        %span.detailed-status__reblogs>= number_to_human status.reblogs_count, strip_insignificant_zeros: true
+        %span.detailed-status__reblogs>= '∞'
         = " "
     ·
     = link_to remote_interaction_path(status, type: :favourite), class: 'modal-button detailed-status__link' do
       = fa_icon('star')
-      %span.detailed-status__favorites>= number_to_human status.favourites_count, strip_insignificant_zeros: true
+      %span.detailed-status__favorites>= '∞'
       = " "
 
     - if user_signed_in?


### PR DESCRIPTION
- TODO: This doesn't seem to work fully for follower/following counts on
  remote servers yet.
- Hide toots/follower/following numbers from profile header
- Obscure status reply/fav/boost counts in public view